### PR TITLE
better support for smaller devices and windows

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@ body,
 #root div {
   margin: 0px;
   height: 100vh;
+  overflow: hidden;
 }
 
 fieldset {

--- a/src/page/expanded-page.css
+++ b/src/page/expanded-page.css
@@ -7,6 +7,10 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+
+  max-width: 100%;
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 /* if we are in light mode, made the shadow more pronounced */


### PR DESCRIPTION
**Before**: cannot scroll through sections if they are too tall, weird scroll bars at the top and bottom
**After**: scrolling through sections uses native scroll pattern, hidden scroll items at top and bottom (performs well on mobile mocks and desktop)

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/1131494/191347641-86097915-1c11-4407-8c6e-4a7c908942e8.png) | ![image](https://user-images.githubusercontent.com/1131494/191347525-5fa9cfde-a350-46cd-a752-a5ffc2028b71.png)
